### PR TITLE
KoinosMQ is no longer a singleton

### DIFF
--- a/koinosmq.go
+++ b/koinosmq.go
@@ -63,8 +63,6 @@ const (
 	rpcReplyToPrefix       = "koinos_rpc_reply_"
 )
 
-var koinosMQ *KoinosMQ
-
 // KoinosMQ AMPQ Golang Wrapper
 //
 // - Each RPC message has an rpcType
@@ -126,11 +124,7 @@ type connection struct {
 
 // NewKoinosMQ factory method.
 func NewKoinosMQ(addr string) *KoinosMQ {
-	if koinosMQ != nil {
-		panic("KoinosMQ is a singleton and can only be created once")
-	}
-
-	mq := KoinosMQ{}
+	mq := new(KoinosMQ)
 	mq.Address = addr
 
 	mq.Handlers.RPCHandlerMap = make(map[string]RPCHandlerFunc)
@@ -140,13 +134,7 @@ func NewKoinosMQ(addr string) *KoinosMQ {
 	mq.Handlers.BroadcastNumConsumers = 1
 	mq.Handlers.RPCReturnNumConsumers = 1
 
-	koinosMQ = &mq
-	return koinosMQ
-}
-
-// GetKoinosMQ returns the created singleton KoinosMQ object
-func GetKoinosMQ() *KoinosMQ {
-	return koinosMQ
+	return mq
 }
 
 // Start begins the connection loop.
@@ -219,10 +207,10 @@ func (mq *KoinosMQ) ConnectLoop() {
 
 // newConnection creates a new Connection
 func (mq *KoinosMQ) newConnection() *connection {
-	conn := connection{}
+	conn := new(connection)
 	conn.Handlers = &mq.Handlers
 	conn.RPCReturnMap = make(map[string]chan rpcReturnType)
-	return &conn
+	return conn
 }
 
 func randInt(min int, max int) int {


### PR DESCRIPTION
This PR gets rid of the global singleton `KoinosMQ` object and allows it to be instantiated multiple times.
