### PR TITLE
Retry RPC policies

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ type Client struct {
 
 	rpcReplyTo string
 
-	rpcRetryPolicy RetryFactory
+	rpcRetryPolicy RetryPolicy
 
 	conn *connection
 }
@@ -54,8 +54,10 @@ type rpcReturnType struct {
 	err  error
 }
 
+const ()
+
 // NewClient factory method.
-func NewClient(addr string, rpcRetryPolicy RetryFactory) *Client {
+func NewClient(addr string, rpcRetryPolicy RetryPolicy) *Client {
 	client := new(Client)
 	client.Address = addr
 
@@ -228,7 +230,7 @@ func (client *Client) makeRPCCall(ctx context.Context, contentType string, rpcTy
 	var callResult *RPCCallResult
 
 	// Ask the retry factory for a new policy instance
-	retry := client.rpcRetryPolicy.CreateInstance()
+	retry := getRetryPolicy(client.rpcRetryPolicy)
 	timeout := retry.PollTimeout()
 
 	for {

--- a/client.go
+++ b/client.go
@@ -228,7 +228,7 @@ func (client *Client) makeRPCCall(ctx context.Context, contentType string, rpcTy
 	var callResult *RPCCallResult
 
 	// Ask the retry factory for a new policy instance
-	retry := client.rpcRetryPolicy()
+	retry := client.rpcRetryPolicy.CreateInstance()
 	timeout := retry.PollTimeout()
 
 	for {
@@ -238,10 +238,11 @@ func (client *Client) makeRPCCall(ctx context.Context, contentType string, rpcTy
 			return
 		}
 
-		// Make a child context with a small timeout, and call the
+		// Make a child context with a small timeout, and call the RPC
 		callCtx, cancel := context.WithTimeout(ctx, rpcAttemptTimeout)
 		defer cancel()
 		callResult = client.tryRPC(callCtx, contentType, rpcType, DurationToUnitString(timeout, time.Millisecond), args)
+		// If there were no errors, we are done
 		if callResult.Error == nil {
 			break
 		}

--- a/retry.go
+++ b/retry.go
@@ -44,14 +44,16 @@ func (rp *NoRetryPolicy) PollTimeout() time.Duration {
 	return noRetryTimeout
 }
 
+// NoRetryFactory is a factory object for no retry policy
 type NoRetryFactory struct {
 }
 
+// CreateInstance creates the policy
 func (f *NoRetryFactory) CreateInstance() RetryPolicy {
 	return &NoRetryPolicy{}
 }
 
-// ExponentialBackoffRetryPolicy will retry with exponentially increasing timeouts
+// ExponentialBackoffPolicy will retry with exponentially increasing timeouts
 type ExponentialBackoffPolicy struct {
 	MaxTimeout time.Duration
 	Exponent   float32
@@ -81,19 +83,21 @@ func (rp *ExponentialBackoffPolicy) CheckRetry(callResult *RPCCallResult) *Check
 	return res
 }
 
+// ExponentialBackoffFactory is a factory object for exponential backoff policy
 type ExponentialBackoffFactory struct {
 }
 
+// CreateInstance creates the policy
 func (f *ExponentialBackoffFactory) CreateInstance() RetryPolicy {
 	return NewDefaultExponentialBackoffPolicy()
 }
 
-// NewExponentialBackoffRetryPolicy will create a new instance
+// NewExponentialBackoffPolicy will create a new instance
 func NewExponentialBackoffPolicy(initialTimeout time.Duration, maxTimeout time.Duration, exponent float32) *ExponentialBackoffPolicy {
 	return &ExponentialBackoffPolicy{MaxTimeout: maxTimeout, Exponent: exponent, nextTimeout: initialTimeout}
 }
 
-// NewDefaultExponentialBackoffRetryPolicy will create a new instance wsith default parameters
+// NewDefaultExponentialBackoffPolicy will create a new instance wsith default parameters
 func NewDefaultExponentialBackoffPolicy() *ExponentialBackoffPolicy {
 	return NewExponentialBackoffPolicy(defaultEBInitialTimeout, defaultEBMaxTimeout, defaultEBExponent)
 }

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,66 @@
+package koinosmq
+
+import "time"
+
+const (
+	defaultEBInitialTimeout = (time.Second * 1)
+	defaultEBMaxTimeout     = (time.Second * 30)
+	defaultEBExponent       = 2.0
+)
+
+// CheckRetryResult represents describes whether a retry is requested, and how long to timeout first
+type CheckRetryResult struct {
+	DoRetry bool
+	Timeout time.Duration
+}
+
+// RetryFactory represent a factory function for producing retry instances
+type RetryFactory func() RetryPolicy
+
+// RetryPolicy interface represents an implementation of an RPC call retry
+type RetryPolicy interface {
+	CheckRetry(*RPCCallResult) *CheckRetryResult
+	PollTimeout() time.Duration
+}
+
+// ----------------------------------------------------------------------------
+// RetryPolicy Implementations
+// ----------------------------------------------------------------------------
+
+// NoRetryPolicy will never retry
+type NoRetryPolicy struct {
+}
+
+// CheckRetry for this policy will always return false
+func (rp NoRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
+	return &CheckRetryResult{DoRetry: false}
+}
+
+// ExponentialBackoffRetryPolicy will retry with exponentially increasing timeouts
+type ExponentialBackoffRetryPolicy struct {
+	MaxTimeout time.Duration
+	Exponent   float32
+
+	nextTimeout time.Duration
+}
+
+// CheckRetry for this policy will return whether or not a retry is reuqested, and how long to timeout
+func (rp ExponentialBackoffRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
+	if rp.nextTimeout > rp.MaxTimeout {
+		return &CheckRetryResult{DoRetry: false}
+	}
+
+	res := &CheckRetryResult{DoRetry: true, Timeout: rp.nextTimeout}
+	rp.nextTimeout *= time.Duration(rp.Exponent)
+	return res
+}
+
+// NewExponentialBackoffRetryPolicy will create a new instance
+func NewExponentialBackoffRetryPolicy(initialTimeout time.Duration, maxTimeout time.Duration, exponent float32) *ExponentialBackoffRetryPolicy {
+	return &ExponentialBackoffRetryPolicy{MaxTimeout: maxTimeout, Exponent: exponent, nextTimeout: initialTimeout}
+}
+
+// NewDefaultExponentialBackoffRetryPolicy will create a new instance wsith default parameters
+func NewDefaultExponentialBackoffRetryPolicy() *ExponentialBackoffRetryPolicy {
+	return NewExponentialBackoffRetryPolicy(defaultEBInitialTimeout, defaultEBMaxTimeout, defaultEBExponent)
+}

--- a/retry.go
+++ b/retry.go
@@ -6,6 +6,7 @@ const (
 	defaultEBInitialTimeout = (time.Second * 1)
 	defaultEBMaxTimeout     = (time.Second * 30)
 	defaultEBExponent       = 2.0
+	noRetryTimeout          = (time.Second * 1)
 )
 
 // CheckRetryResult represents describes whether a retry is requested, and how long to timeout first
@@ -32,8 +33,13 @@ type NoRetryPolicy struct {
 }
 
 // CheckRetry for this policy will always return false
-func (rp NoRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
+func (rp *NoRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
 	return &CheckRetryResult{DoRetry: false}
+}
+
+// PollTimeout for this policy always returns a default value
+func (rp *NoRetryPolicy) PollTimeout() time.Duration {
+	return noRetryTimeout
 }
 
 // ExponentialBackoffRetryPolicy will retry with exponentially increasing timeouts
@@ -44,8 +50,13 @@ type ExponentialBackoffRetryPolicy struct {
 	nextTimeout time.Duration
 }
 
+// PollTimeout for this policy simply returns the next timeout value
+func (rp *ExponentialBackoffRetryPolicy) PollTimeout() time.Duration {
+	return rp.nextTimeout
+}
+
 // CheckRetry for this policy will return whether or not a retry is reuqested, and how long to timeout
-func (rp ExponentialBackoffRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
+func (rp *ExponentialBackoffRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
 	if rp.nextTimeout > rp.MaxTimeout {
 		return &CheckRetryResult{DoRetry: false}
 	}


### PR DESCRIPTION
Adds a new interface, `RPCPolicy` which represents a method for attempting retries when an RPC call fails.
There are two implementations currently, `NoRetryPolicy`, and `ExponentialBackoffPolicy`

Resolves #16