### PR TITLE
Backoff Bug

### DIFF
--- a/client.go
+++ b/client.go
@@ -255,7 +255,7 @@ func (client *Client) makeRPCCall(ctx context.Context, contentType string, rpcTy
 		}
 
 		// See if the policy requests a retry
-		retryResult := retry.CheckRetry(callResult)
+		retryResult := retry.CheckRetry()
 		if !retryResult.DoRetry {
 			log.Warnf("RPC failed with error: %v", callResult.Error)
 			break

--- a/retry.go
+++ b/retry.go
@@ -27,7 +27,7 @@ const (
 
 type retryPolicyInterface interface {
 	SetOptions(interface{})
-	CheckRetry(*RPCCallResult) *CheckRetryResult
+	CheckRetry() *CheckRetryResult
 	PollTimeout() time.Duration
 }
 
@@ -65,7 +65,7 @@ type noRetryPolicy struct {
 
 func (rp *noRetryPolicy) SetOptions(interface{}) {}
 
-func (rp *noRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
+func (rp *noRetryPolicy) CheckRetry() *CheckRetryResult {
 	return &CheckRetryResult{DoRetry: false}
 }
 
@@ -94,8 +94,8 @@ func (rp *exponentialBackoffRetryPolicy) PollTimeout() time.Duration {
 	return rp.options.NextTimeout
 }
 
-func (rp *exponentialBackoffRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
-	rp.options.NextTimeout *= time.Duration(rp.options.Exponent)
+func (rp *exponentialBackoffRetryPolicy) CheckRetry() *CheckRetryResult {
+	rp.options.NextTimeout = rp.options.NextTimeout * time.Duration(rp.options.Exponent)
 
 	if rp.options.NextTimeout > rp.options.MaxTimeout {
 		rp.options.NextTimeout = rp.options.MaxTimeout

--- a/retry.go
+++ b/retry.go
@@ -40,7 +40,7 @@ func getRetryPolicy(policy RetryPolicy, options ...interface{}) retryPolicyInter
 	case ExponentialBackoff:
 		rp = &exponentialBackoffRetryPolicy{
 			options: ExponentialBackoffOptions{
-				MaxTimeout:  defaultEBInitialTimeout,
+				MaxTimeout:  defaultEBMaxTimeout,
 				Exponent:    defaultEBExponent,
 				NextTimeout: defaultEBInitialTimeout,
 			},

--- a/retry.go
+++ b/retry.go
@@ -95,11 +95,11 @@ func (rp *exponentialBackoffRetryPolicy) PollTimeout() time.Duration {
 }
 
 func (rp *exponentialBackoffRetryPolicy) CheckRetry(callResult *RPCCallResult) *CheckRetryResult {
+	rp.options.NextTimeout *= time.Duration(rp.options.Exponent)
+
 	if rp.options.NextTimeout > rp.options.MaxTimeout {
-		return &CheckRetryResult{DoRetry: false}
+		rp.options.NextTimeout = rp.options.MaxTimeout
 	}
 
-	res := &CheckRetryResult{DoRetry: true, Timeout: rp.options.NextTimeout}
-	rp.options.NextTimeout *= time.Duration(rp.options.Exponent)
-	return res
+	return &CheckRetryResult{DoRetry: true, Timeout: rp.options.NextTimeout}
 }

--- a/retry.go
+++ b/retry.go
@@ -95,11 +95,13 @@ func (rp *exponentialBackoffRetryPolicy) PollTimeout() time.Duration {
 }
 
 func (rp *exponentialBackoffRetryPolicy) CheckRetry() *CheckRetryResult {
+	retry := CheckRetryResult{DoRetry: true, Timeout: rp.options.NextTimeout}
+
 	rp.options.NextTimeout = rp.options.NextTimeout * time.Duration(rp.options.Exponent)
 
 	if rp.options.NextTimeout > rp.options.MaxTimeout {
 		rp.options.NextTimeout = rp.options.MaxTimeout
 	}
 
-	return &CheckRetryResult{DoRetry: true, Timeout: rp.options.NextTimeout}
+	return &retry
 }


### PR DESCRIPTION
Closes #22

Confirmed logs are:

```
2021-04-26 21:13:50.990832 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:265] <warn>: RPC error: AMQP connection is not open
2021-04-26 21:13:50.992031 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:266] <warn>: Trying again in 1 seconds
2021-04-26 21:13:51.895599 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:265] <warn>: RPC error: context deadline exceeded
2021-04-26 21:13:51.896333 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:266] <warn>: Trying again in 1 seconds
2021-04-26 21:13:51.935612 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/connection.go:85] <info>: Dialing AMQP server amqp://guest:guest@amqp:5672/
2021-04-26 21:13:51.941799 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/connection.go:88] <error>: AMQP error dialing server: dial tcp 192.168.160.2:5672: connect: connection refused
2021-04-26 21:13:51.952511 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/connection.go:85] <info>: Dialing AMQP server amqp://guest:guest@amqp:5672/
2021-04-26 21:13:51.954477 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/connection.go:88] <error>: AMQP error dialing server: dial tcp 192.168.160.2:5672: connect: connection refused
2021-04-26 21:13:51.994180 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:265] <warn>: RPC error: AMQP connection is not open
2021-04-26 21:13:51.994852 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:266] <warn>: Trying again in 2 seconds
2021-04-26 21:13:52.897685 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:265] <warn>: RPC error: AMQP connection is not open
2021-04-26 21:13:52.898485 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:266] <warn>: Trying again in 2 seconds
2021-04-26 21:13:53.996307 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:265] <warn>: RPC error: AMQP connection is not open
2021-04-26 21:13:53.997632 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:266] <warn>: Trying again in 4 seconds
2021-04-26 21:13:54.899805 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:265] <warn>: RPC error: AMQP connection is not open
2021-04-26 21:13:54.900797 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20210426210626-3dedb8892179/client.go:266] <warn>: Trying again in 4 seconds
```