### PR TITLE
Connect on start

### DIFF
--- a/client.go
+++ b/client.go
@@ -84,14 +84,11 @@ func NewClient(addr string, rpcRetryPolicy RetryPolicy) *Client {
 }
 
 // Start begins the connection loop. Blocks until first connected to AMQP
-func (client *Client) Start(ctx context.Context) {
+func (client *Client) Start(ctx context.Context) <-chan struct{} {
 	connectedChan := make(chan struct{}, 1)
 	go client.connectLoop(ctx, connectedChan)
 
-	select {
-	case <-connectedChan:
-	case <-ctx.Done():
-	}
+	return connectedChan
 }
 
 // SetNumConsumers sets the number of consumers for queues.

--- a/request_handler.go
+++ b/request_handler.go
@@ -61,14 +61,11 @@ func NewRequestHandler(addr string, consumers uint) *RequestHandler {
 }
 
 // Start begins the connection loop.
-func (r *RequestHandler) Start(ctx context.Context) {
+func (r *RequestHandler) Start(ctx context.Context) <-chan struct{} {
 	connectedChan := make(chan struct{}, 1)
 	go r.connectLoop(ctx, connectedChan)
 
-	select {
-	case <-connectedChan:
-	case <-ctx.Done():
-	}
+	return connectedChan
 }
 
 // SetRPCHandler sets the RPC handler for an RPC type.

--- a/request_handler.go
+++ b/request_handler.go
@@ -160,6 +160,8 @@ func (r *RequestHandler) consumeRPCLoop(ctx context.Context, consumer <-chan amq
 				return
 			}
 
+			log.Debugf("Request handler received message: %v", delivery)
+
 			r.deliveryChan <- &rpcDelivery{
 				delivery:    &delivery,
 				isBroadcast: false,
@@ -179,6 +181,8 @@ func (r *RequestHandler) consumeBroadcastLoop(ctx context.Context, consumer <-ch
 			if !ok {
 				return
 			}
+
+			log.Debugf("Request handler received message: %v", delivery)
 
 			r.deliveryChan <- &rpcDelivery{
 				delivery:    &delivery,


### PR DESCRIPTION
## Brief description

Allows users of `mq-golang` to wait on channel for connection to succeed

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
