### PR TITLE
Cleanup tryRPCResponse and send response correctly when no error

### DIFF
--- a/client.go
+++ b/client.go
@@ -189,7 +189,7 @@ func (c *Client) tryBroadcast(ctx context.Context, contentType ContentType, topi
 		return errors.New("AMQP connection is not open")
 	}
 
-	err := c.conn.AmqpChan.PublishWithContext(
+	return c.conn.AmqpChan.PublishWithContext(
 		ctx,
 		broadcastExchangeName,
 		topic,
@@ -200,8 +200,6 @@ func (c *Client) tryBroadcast(ctx context.Context, contentType ContentType, topi
 			Body:        args,
 		},
 	)
-
-	return err
 }
 
 // Broadcast a message via AMQP

--- a/request_handler.go
+++ b/request_handler.go
@@ -214,31 +214,25 @@ func (r *RequestHandler) tryRPCResponse(ctx context.Context, delivery *amqp.Deli
 	r.connMutex.Lock()
 	defer r.connMutex.Unlock()
 
-	var err error
-
 	if (r.conn == nil) || !r.conn.IsOpen() {
-		err = errors.New("AMQP connection is not open")
+		return errors.New("AMQP connection is not open")
 	}
 
-	if err != nil {
-		err = r.conn.AmqpChan.PublishWithContext(
-			ctx,
-			rpcExchangeName,  // Exchange
-			delivery.ReplyTo, // Routing key (channel name for default exchange)
-			false,            // Mandatory
-			false,            // Immediate
-			amqp.Publishing{
-				DeliveryMode:  amqp.Transient,
-				Timestamp:     time.Now(),
-				ContentType:   delivery.ContentType,
-				CorrelationId: delivery.CorrelationId,
-				Body:          output,
-				Expiration:    expiration,
-			},
-		)
-	}
-
-	return err
+	return r.conn.AmqpChan.PublishWithContext(
+		ctx,
+		rpcExchangeName,  // Exchange
+		delivery.ReplyTo, // Routing key (channel name for default exchange)
+		false,            // Mandatory
+		false,            // Immediate
+		amqp.Publishing{
+			DeliveryMode:  amqp.Transient,
+			Timestamp:     time.Now(),
+			ContentType:   delivery.ContentType,
+			CorrelationId: delivery.CorrelationId,
+			Body:          output,
+			Expiration:    expiration,
+		},
+	)
 }
 
 func (r *RequestHandler) handleRPCDelivery(ctx context.Context, rpcType string, delivery *amqp.Delivery) {


### PR DESCRIPTION
## Brief description

Correctly send a response when the connection is open

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
