### PR TITLE
Effectively wait on the parent context when no retry policy is set

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -1,12 +1,15 @@
 package koinosmq
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 const (
 	defaultEBInitialTimeout = (time.Second * 1)
 	defaultEBMaxTimeout     = (time.Second * 30)
 	defaultEBExponent       = 2.0
-	noRetryTimeout          = (time.Second * 1)
+	noRetryTimeout          = (time.Second * math.MaxInt32)
 )
 
 // CheckRetryResult represents describes whether a retry is requested, and how long to timeout first


### PR DESCRIPTION
## Brief description

Set no retry timeout such that when no retry is set, the parent context timeout is used.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
