### PR TITLE
Revert "Effectively wait on the parent context when no retry policy is set"

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -1,15 +1,12 @@
 package koinosmq
 
-import (
-	"math"
-	"time"
-)
+import "time"
 
 const (
 	defaultEBInitialTimeout = (time.Second * 1)
 	defaultEBMaxTimeout     = (time.Second * 30)
 	defaultEBExponent       = 2.0
-	noRetryTimeout          = (time.Second * math.MaxInt32)
+	noRetryTimeout          = (time.Second * 1)
 )
 
 // CheckRetryResult represents describes whether a retry is requested, and how long to timeout first


### PR DESCRIPTION
Reverts koinos/koinos-mq-golang#37